### PR TITLE
Fix a bug where the component can be null in the middle of AbstractCo…

### DIFF
--- a/client/src/model/component/CircuitDiagram.hx
+++ b/client/src/model/component/CircuitDiagram.hx
@@ -176,20 +176,17 @@ class CircuitDiagram extends Observable implements CircuitDiagramI implements Ob
 
     public function findHitList(coordinate:Coordinate, mode:MODE):Array<HitObject>{
         var hitObjectArray:Array<HitObject> = new Array<HitObject>();
-        var hitLinkArray:Array<HitObject> = new Array<HitObject>();
-        for(i in linkArray){
-            hitLinkArray = i.findHitList(coordinate, mode);
-            for(j in hitLinkArray){
+        
+        for(link in linkArray){
+            var result = link.findHitList(coordinate, mode);
+            for(j in result){
                 j.set_circuitDiagram(this);
-
                 hitObjectArray.push(j);
             }
         }
 
-        var result:Array<HitObject> = new Array<HitObject>();
-        for(i in componentArray){
-            result = i.findHitList(coordinate, mode) ;
-
+        for(comp in componentArray) {
+            var result = comp.findHitList(coordinate, mode) ;
             for(j in result){
                 if(j.get_circuitDiagram() == null){
                     j.set_circuitDiagram(this);

--- a/client/src/model/component/Component.hx
+++ b/client/src/model/component/Component.hx
@@ -207,7 +207,7 @@ class Component extends CircuitElement {
     }
 
     public function findHitList(coordinate:Coordinate, mode:MODE):Array<HitObject>{
-        return componentKind.findHitList(this, coordinate, mode);
+        return componentKind.findHitList(this, coordinate, mode, true);
     }
 
     public function findWorldPoint(coordinate:Coordinate, mode:POINT_MODE):Array<WorldPoint>{

--- a/client/src/model/component/Component.hx
+++ b/client/src/model/component/Component.hx
@@ -69,6 +69,13 @@ class Component extends CircuitElement {
         this.attributeValueList = new AttributeValueList( this.componentKind.getAttributes() ) ;
     }
 
+    public function toString() : String {
+        return "Component( kind: " + componentKind
+                         + " x:" + xPosition
+                         + " y:" + yPosition
+                         + ")" ;
+    }
+
     public function getAttributes( ) : Iterator< AttributeUntyped > {
         return attributeValueList.getAttributes() ;
     }

--- a/client/src/model/gates/AbstractComponentKind.hx
+++ b/client/src/model/gates/AbstractComponentKind.hx
@@ -70,7 +70,7 @@ class AbstractComponentKind  {
     :Array<HitObject> {
         var hitObjectArray:Array<HitObject> = new Array<HitObject>();
 
-        if( includeSelf && isInComponent(component, coordinate) ){
+        if( includeSelf && isInComponent(component, coordinate) ) {
             var hitObject:HitObject = new HitObject();
             hitObject.set_component(component);
             hitObjectArray.push(hitObject);

--- a/client/src/model/gates/AbstractComponentKind.hx
+++ b/client/src/model/gates/AbstractComponentKind.hx
@@ -66,12 +66,11 @@ class AbstractComponentKind  {
         //TODO
     }
 
-    public function findHitList(component : Component, coordinate:Coordinate, mode:MODE)
+    public function findHitList(component : Component, coordinate:Coordinate, mode:MODE, includeSelf : Bool )
     :Array<HitObject> {
         var hitObjectArray:Array<HitObject> = new Array<HitObject>();
 
-        var component:Component = isInComponent(component, coordinate);
-        if(component != null){
+        if( includeSelf && isInComponent(component, coordinate) ){
             var hitObject:HitObject = new HitObject();
             hitObject.set_component(component);
             hitObjectArray.push(hitObject);
@@ -93,11 +92,10 @@ class AbstractComponentKind  {
     * @return if the coordinate in a component then return the component
     *           or  return null;
     **/
-    function isInComponent(component : Component, coordinate:Coordinate):Component {
-        if(isInScope(component.get_xPosition(), component.get_yPosition(), coordinate.get_xPosition(), coordinate.get_yPosition(), component.get_height(), component.get_width())){
-            return component;
-        }
-        return null;
+    function isInComponent(component : Component, coordinate:Coordinate) : Bool {
+        return isInScope(component.get_xPosition(), component.get_yPosition(),
+                         coordinate.get_xPosition(), coordinate.get_yPosition(),
+                         component.get_height(), component.get_width()) ;
     }
 
     /**
@@ -111,11 +109,10 @@ class AbstractComponentKind  {
      * @reutrn if in the scope, return true; otherwise, return false;
     **/
     function isInScope(orignalXposition:Float, orignalYposition:Float, mouseXPosition:Float, mouseYposition:Float, heigh:Float, width:Float):Bool{
-        if((mouseXPosition >= orignalXposition - width/2 && mouseXPosition <= orignalXposition + width/2)&&(mouseYposition >= orignalYposition - heigh/2 && mouseYposition <= orignalYposition + heigh/2)){
-            return true;
-        }else{
-            return false;
-        }
+        return  mouseXPosition >= orignalXposition - width/2 
+             && mouseXPosition <= orignalXposition + width/2
+             && mouseYposition >= orignalYposition - heigh/2
+             && mouseYposition <= orignalYposition + heigh/2 ;
     }
 
     /**

--- a/client/src/model/gates/ComponentKind.hx
+++ b/client/src/model/gates/ComponentKind.hx
@@ -48,9 +48,17 @@ interface ComponentKind {
     public function drawComponent( component : Component, drawingAdapter:DrawingAdapterI, hightLight:Bool, selection : SelectionModel ):Void;
 
     /**
-    * find the hit list
+    * Find the hit list
+    * @param component A component.
+    * @param coordinate A point
+    * @param mode If this is include parent, then white box compound components will be included
+    * @param includeSelf Should the component itself be included, or only its children.
+    *   (This should be set to true. The false value is only used internally.)
+    * @return An array of all things hit. This may include the component itself and its ports.
+    * If the component is a white box compound component, the array may also include components, ports,
+    * links, and endpoints that are within the component.
     **/
-    public function findHitList(component : Component, coordinate:Coordinate, mode:MODE):Array<HitObject>;
+    public function findHitList(component : Component, coordinate:Coordinate, mode:MODE, includeSelf : Bool ):Array<HitObject>;
 
     /**
     * find world point

--- a/client/src/model/gates/CompoundComponent.hx
+++ b/client/src/model/gates/CompoundComponent.hx
@@ -153,29 +153,20 @@ class CompoundComponent implements ComponentKind extends AbstractComponentKind{
         return transform;
     }
 
-    override public function findHitList(component : Component, outerWorldCoordinates:Coordinate, mode:MODE):Array<HitObject>{
-        var hitObjectArray:Array<HitObject> = new Array<HitObject>();
+    override public function findHitList(component : Component, outerWorldCoordinates:Coordinate, mode:MODE, includeSelf : Bool ):Array<HitObject>{
+        var hitObjectArray:Array<HitObject> = super.findHitList(component, outerWorldCoordinates, mode, mode==MODE.INCLUDE_PARENTS) ;
 
-        var hitComponent:Component = isInComponent(component, outerWorldCoordinates);
-        if(hitComponent == null){
-            return hitObjectArray;
-        }else if(component.get_boxType() == BOX.WHITE_BOX){
+        if( isInComponent(component, outerWorldCoordinates) && 
+            component.get_boxType() == BOX.WHITE_BOX )
+        {
             var transform:Transform = makeTransform(component);
             var innerWorldCoordinates:Coordinate = transform.pointInvert(outerWorldCoordinates);
             var result:Array<HitObject> = circuitDiagram.findHitList(innerWorldCoordinates, mode);
-
-            if(result.length == 0 || mode == MODE.INCLUDE_PARENTS){
-                var hitObject:HitObject = new HitObject();
-                hitObject.set_component(component);
-                result.push(hitObject);
+            for( hitOject in result ) {
+                hitObjectArray.push( hitOject ) ;
             }
-            return result;
-        }else{
-            var hitObject:HitObject = new HitObject();
-            hitObject.set_component(component);
-            hitObjectArray.push(hitObject);
-            return hitObjectArray;
         }
+        return hitObjectArray ;
     }
 
     override public function findWorldPoint(component : Component,

--- a/client/src/type/HitObject.hx
+++ b/client/src/type/HitObject.hx
@@ -16,6 +16,15 @@ class HitObject {
 
     }
 
+    public function toString() : String {
+        return "Hit object( "
+        + (if(component != null)  " "+component else "" )
+        + (if(link != null)  " "+link else "" )
+        + (if(port != null)  " "+port else "")
+        + (if(endpoint != null)  " "+endpoint else "")
+        + ")" ;
+    }
+
     public function hitNothing():Bool{
         if(component == null && link == null && port == null && endpoint == null){
             return true;

--- a/client/testSrc/TestFindHits.hx
+++ b/client/testSrc/TestFindHits.hx
@@ -1,0 +1,93 @@
+import buddy.* ;
+using buddy.Should;
+
+import assertions.Assert ;
+import model.component.* ;
+import model.gates.* ;
+import model.enumeration.MODE;
+import model.enumeration.Orientation ;
+import type.Coordinate;
+import type.HitObject ;
+
+class TestFindHits extends SingleSuite {
+    public function new() {
+        // A test suite:
+        describe("HitList", {
+            var cd : CircuitDiagramI ;
+
+            beforeEach({
+                cd = new CircuitDiagram() ;
+            });
+
+            it("should find components and ports", {
+                var kind = new XOR() ;
+                var comp0 = new Component( cd, 100, 200, 40, 40, Orientation.EAST, kind ) ;
+                cd.addComponent( comp0 ) ;
+
+                var outPort0 = comp0.get_ports().next() ;
+                // Check that it is where I think it should be.
+                outPort0.get_xPosition().should.be( 120 ) ;
+                outPort0.get_yPosition().should.be( 200 ) ;
+
+                var comp1 = new Component( cd, 120, 220, 40, 40, Orientation.EAST, kind ) ;
+                cd.addComponent( comp1 ) ;
+                cd.checkInvariant() ;
+
+                { // Hit comp 0
+                    var hits = cd.findHitList( new Coordinate( 90, 190), MODE.INCLUDE_PARENTS ) ;
+                    hits.length.should.be( 1 ) ;
+                    var h0 = hits[0] ;
+                    var c0 = h0.get_component() ;
+                    c0.should.be(comp0) ;
+                }
+
+                {  // Hit both components 
+                    var hits = cd.findHitList( new Coordinate( 110, 210 ), MODE.INCLUDE_PARENTS ) ;
+                    hits.length.should.be( 2 ) ;
+                    var h0 = hits[0] ;
+                    var h1 = hits[1] ;
+                    var c0 = h0.get_component() ;
+                    var c1 = h1.get_component() ;
+                    if( c0 == comp0 ) {
+                        c1.should.be( comp1 ) ;
+                    } else {
+                        c0.should.be( comp1 ) ;
+                        c1.should.be( comp0 ) ;
+                    }
+                }
+
+                {   // Hit both components and the output port of comp 1.
+                    // Here we miss the port by a distance of (-1,+1). It should still hit.
+                    var hits = cd.findHitList( new Coordinate( 119, 201 ), MODE.INCLUDE_PARENTS ) ;
+                    hits.length.should.be( 3 ) ;
+
+                    var ports = new Array<Port>() ;
+                    var comps = new Array<Component>() ;
+                    for( h in hits ) {
+                        if( h.get_component() != null ) comps.push( h.get_component() ) ;
+                        if( h.get_port() != null ) ports.push( h.get_port() ) ;
+                    }
+
+                    ports.length.should.be(1) ;
+                    // Check it is the out port of the first gate.
+                    ports[0].should.be( outPort0 ) ;
+
+
+                    comps.length.should.be(2) ;
+                    if( comps[0] == comp0 ) {
+                        comps[1].should.be( comp1 ) ;
+                    } else {
+                        comps[0].should.be( comp1 ) ;
+                        comps[1].should.be( comp0 ) ;
+                    }
+                }
+
+
+            });
+
+            afterEach({
+            });
+        });
+        
+    }
+}

--- a/client/testSrc/TestMain.hx
+++ b/client/testSrc/TestMain.hx
@@ -5,7 +5,8 @@ using buddy.Should;
 
 class TestMain implements Buddy< [
     TestThatBuddyWorks,
-    TestCircuitDiagram
+    TestCircuitDiagram,
+    TestFindHits
 ] > { }
 
 class TestThatBuddyWorks extends SingleSuite {


### PR DESCRIPTION
…mponentKind.findHitList.

Simplify interpretation of findHitList. It only includes white box compound components when the mode is INCLUDE_PARENTS;
formerlly the compound component would be included when none of its elements were hit, even if the mode was not INCLUDE_PARENTS.